### PR TITLE
Fixed wrong "else if" condition

### DIFF
--- a/HohhaDynamicXOR.c
+++ b/HohhaDynamicXOR.c
@@ -1090,7 +1090,7 @@ void CheckOptimizedVersion(unsigned NumJumps, unsigned BodyLen)
       CheckSumReturnedFromDecryptor = xorDecryptHOP2(KeyBuf, (uint8_t *)(&SaltData), KeyCheckSum, DLen+1, Data);
     else if (NumJumps == 3)
       CheckSumReturnedFromDecryptor = xorDecryptHOP3(KeyBuf, (uint8_t *)(&SaltData), KeyCheckSum, DLen+1, Data);
-    else if (NumJumps == 3)
+    else if (NumJumps == 4)
       CheckSumReturnedFromDecryptor = xorDecryptHOP4(KeyBuf, (uint8_t *)(&SaltData), KeyCheckSum, DLen+1, Data);
     else exit(-1);
     


### PR DESCRIPTION
In line `1093` there's a second `else if (NumJumps == 3)` (which can never happen to be true, since there is another one in line `1091`)
